### PR TITLE
delay elements can be edited

### DIFF
--- a/src/components/macroview/EditArea.tsx
+++ b/src/components/macroview/EditArea.tsx
@@ -1,12 +1,17 @@
-import { VStack, Text } from '@chakra-ui/react'
+import { VStack, Text, Input, ButtonGroup, Button, Flex, Select, Grid, GridItem } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 import { useSelectedElement } from '../../contexts/selectors'
 import { useSequenceContext } from '../../contexts/sequenceContext'
+import { DelayUnit } from '../../enums'
 import { HIDLookup } from '../../maps/HIDmap'
+import { ActionEventType } from '../../types'
 
 const EditArea = () => {
+  const [currentTypeIndex, setCurrentTypeIndex] = useState(0)
   const [displayText, setDisplayText] = useState<string | undefined>('')
-  const { selectedElementIndex } = useSequenceContext()
+  const [delayDuration, setDelayDuration] = useState<number>(0)
+  const [delayUnit, setDelayUnit] = useState<DelayUnit>(DelayUnit.Milliseconds)
+  const { sequence, selectedElementIndex } = useSequenceContext()
   const selectedElement = useSelectedElement()
 
   useEffect(() => {
@@ -18,14 +23,28 @@ const EditArea = () => {
         setDisplayText(
           HIDLookup.get(selectedElement.data.data.keypress)?.displayString
         )
+        setCurrentTypeIndex(0)
         break
       case 'Delay':
-        setDisplayText(selectedElement.data.data.toString() + 'ms')
+        setDisplayText(selectedElement.data.data.toString())
+        setDelayDuration(selectedElement.data.data)
+        setCurrentTypeIndex(1)
         break
       default:
         break
     }
   }, [selectedElement])
+
+
+  const onDelayDurationChange = (event:any) => {
+    setDelayDuration(event.target.value)
+    // update
+    // TODO: fix element display in sequencing area not updating when fields are changed
+    selectedElement.data.data = parseInt(event.target.value)
+  }
+  const onDelayUnitChange = (event:any) => {
+    setDelayUnit(event.target.value)
+  }
 
   if (selectedElementIndex === 0) {
     return (
@@ -48,6 +67,42 @@ const EditArea = () => {
     )
   }
 
+  if (currentTypeIndex === 1) {
+    return(
+      <VStack w="25%" h="full" borderLeft="1px" borderColor="gray.200" alignItems="normal" p="3">
+        <Text fontWeight="semibold" fontSize={['sm', 'md']}>
+          {selectedElement.data.type}
+        </Text>
+        <Grid templateRows='repeat(2, 1fr)' gap="0px">
+          <GridItem w='100%' h="8px" alignItems="center" justifyContent="center">
+            <Text>Duration</Text>
+          </GridItem>
+          <GridItem w='100%'>
+            <Flex gap={['4px']} alignItems="center" justifyContent="space-around">
+              <Input
+                maxW={['50%', '65%', '75%']}
+                maxH="32px"
+                variant="outline"
+                borderColor="gray.400"
+                value={delayDuration} onChange={onDelayDurationChange}
+              />
+              <Select value={delayUnit} onChange={onDelayUnitChange}
+                maxW={['50%', '35%', '25%']}
+                >
+                <option value={DelayUnit.Milliseconds}>ms</option>
+                <option value={DelayUnit.Seconds}>s</option>
+                <option value={DelayUnit.Minutes}>min</option>
+              </Select>
+            </Flex>
+          </GridItem>
+        </Grid>
+
+        <Button variant="outline" colorScheme='blue' onClick={() => setDelayDuration(50)}>Set to Default</Button>
+      </VStack>
+    )
+  }
+
+  // default for keypress
   return (
     <VStack w="25%" h="full" borderLeft="1px" borderColor="gray.200">
       <Text fontWeight="semibold" fontSize={['sm', 'md']}>

--- a/src/components/macroview/SequenceElementDraggableDisplay.tsx
+++ b/src/components/macroview/SequenceElementDraggableDisplay.tsx
@@ -17,9 +17,6 @@ type Props = {
   element: SequenceElement
 }
 
-// TODO:
-// 1. variant for Delay Element required
-
 const SequenceElementDraggableDisplay = ({ element }: Props) => {
   const [isSmallVariant, setIsSmallVariant] = useState(false)
   const [displayText, setDisplayText] = useState<string | undefined>('')
@@ -48,7 +45,7 @@ const SequenceElementDraggableDisplay = ({ element }: Props) => {
         break
       case 'Delay':
         setIsSmallVariant(true)
-        setDisplayText(element.data.data.toString() + 'ms')
+        setDisplayText(element.data.data.toString() + ' ms')
         break
       default:
         break

--- a/src/components/macroview/SequencingArea.tsx
+++ b/src/components/macroview/SequencingArea.tsx
@@ -23,6 +23,7 @@ const SequencingArea = () => {
       const newIndex = sequence.findIndex(
         (element) => element.id === event.over.id
       )
+
       overwriteSequence(arrayMove(sequence, oldIndex, newIndex))
     }
   }

--- a/src/components/overview/MacroCard.tsx
+++ b/src/components/overview/MacroCard.tsx
@@ -68,9 +68,9 @@ function MacroCard({ macro, index, onDelete }: Props) {
             variant="link"
           ></MenuButton>
           <MenuList>
-            <MenuItem>Duplicate</MenuItem>
-            <MenuItem>Move to Collection</MenuItem>
-            <MenuItem>Export</MenuItem>
+            <MenuItem isDisabled>Duplicate</MenuItem>
+            <MenuItem isDisabled>Move to Collection</MenuItem>
+            <MenuItem isDisabled>Export</MenuItem>
             <Divider />
             <MenuItem onClick={() => onDelete(index)} textColor="red.500">
               Delete

--- a/src/contexts/selectors.ts
+++ b/src/contexts/selectors.ts
@@ -32,5 +32,5 @@ export function useSequence() {
 
 export function useSelectedElement() {
   const context = useSequenceContext()
-  return context.sequence[context.selectedElementIndex - 1]
+  return context.sequence[context.sequence.findIndex((element) => element.id === context.selectedElementIndex)]
 }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -21,3 +21,9 @@ export enum KeyType {
   Up,
   DownUp
 }
+
+export enum DelayUnit {
+  Milliseconds,
+  Seconds,
+  Minutes
+}


### PR DESCRIPTION
- added new enum for delay units
- fixed useSelectedElement() not returning the correct element after elements have been moved around