### PR TITLE
adjusted alert for sequence elements that are also trigger keys

### DIFF
--- a/src/components/overview/CollectionModal.tsx
+++ b/src/components/overview/CollectionModal.tsx
@@ -21,13 +21,12 @@ import { useApplicationContext } from '../../contexts/applicationContext'
 import { useSelectedCollection } from '../../contexts/selectors'
 import data from '@emoji-mart/data'
 import Picker from '@emoji-mart/react'
+import { maxNameLength } from '../../utils'
 
 type Props = {
   isOpen: boolean
   onClose: () => void
 }
-
-const maxNameLength = 25
 
 export default function CollectionModal({ isOpen, onClose }: Props) {
   const [collectionName, setCollectionName] = useState('')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,8 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { MouseButton } from './enums'
 import { ApplicationConfig, Collection, MacroData } from './types'
 
+export const maxNameLength = 25
+
 export const updateBackendConfig = (collections: Collection[]) => {
   const macroData: MacroData = { data: collections }
   invoke<void>('set_macros', { frontendData: macroData }).catch((e) => {


### PR DESCRIPTION
The alert now appears properly when a user adds an element that is also the trigger key(s) of the current macro, and also properly goes away when changing the trigger key to be something else

Also, the name of the macro must now be unique, and thus the constraint has been added to the macro name input field