### PR TITLE
fix editing names for macro and collection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,10 @@ import { ViewState } from './enums'
 import { useApplicationContext } from './contexts/applicationContext'
 import Macroview from './views/Macroview'
 import { useEffect } from 'react'
-import { MacroProvider } from './contexts/macroContext'
 import SettingsModal from './views/settings/SettingsModal'
 import data from '@emoji-mart/data'
 import { init } from 'emoji-mart'
-import "./App.css"
+import './App.css'
 
 function App() {
   const { viewState, initComplete } = useApplicationContext()
@@ -34,16 +33,8 @@ function App() {
       {viewState === ViewState.Overview && (
         <Overview onOpenSettingsModal={onOpen} />
       )}
-      {viewState === ViewState.Addview && (
-        <MacroProvider key={0}>
-          <Macroview />
-        </MacroProvider>
-      )}
-      {viewState === ViewState.Editview && (
-        <MacroProvider key={1}>
-          <Macroview />
-        </MacroProvider>
-      )}
+      {viewState === ViewState.Addview && <Macroview key={0} />}
+      {viewState === ViewState.Editview && <Macroview key={1} />}
       <SettingsModal isOpen={isOpen} onClose={onClose} />
     </Flex>
   )

--- a/src/components/overview/CollectionModal.tsx
+++ b/src/components/overview/CollectionModal.tsx
@@ -39,26 +39,31 @@ export default function CollectionModal({ isOpen, onClose }: Props) {
     onCollectionAdd,
     onCollectionUpdate
   } = useApplicationContext()
-  const collection = useSelectedCollection()
+  const currentCollection = useSelectedCollection()
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const borderColour = useColorModeValue('stone.500', 'zinc.500')
 
   useEffect(() => {
     if (isUpdatingCollection) {
-      setIconString(collection.icon)
-      setCollectionName(collection.name)
+      setIconString(currentCollection.icon)
+      setCollectionName(currentCollection.name)
       setIsNameUsable(true)
     } else {
       setIconString(':smile:')
       setCollectionName('')
       setIsNameUsable(false)
     }
-  }, [collection.icon, collection.name, isOpen, isUpdatingCollection])
+  }, [
+    currentCollection.icon,
+    currentCollection.name,
+    isOpen,
+    isUpdatingCollection
+  ])
 
   const onModalSuccessClose = useCallback(() => {
     if (isUpdatingCollection) {
       onCollectionUpdate(
-        { ...collection, name: collectionName, icon: iconString },
+        { ...currentCollection, name: collectionName, icon: iconString },
         selection.collectionIndex
       )
     } else {
@@ -71,7 +76,7 @@ export default function CollectionModal({ isOpen, onClose }: Props) {
     }
     onClose()
   }, [
-    collection,
+    currentCollection,
     collectionName,
     iconString,
     isUpdatingCollection,
@@ -93,6 +98,16 @@ export default function CollectionModal({ isOpen, onClose }: Props) {
         return
       }
 
+      if (isUpdatingCollection) {
+        if (
+          newName.trim().toUpperCase() === currentCollection.name.toUpperCase()
+        ) {
+          setCollectionName(newName)
+          setIsNameUsable(true)
+          return
+        }
+      }
+
       for (let i = 0; i < collections.length; i++) {
         const collection = collections[i]
         if (collection.name.toUpperCase() === newName.trim().toUpperCase()) {
@@ -104,7 +119,7 @@ export default function CollectionModal({ isOpen, onClose }: Props) {
       setCollectionName(newName)
       setIsNameUsable(true)
     },
-    [collections]
+    [currentCollection.name, collections, isUpdatingCollection]
   )
 
   const onEmojiSelect = useCallback(

--- a/src/components/overview/MacroCard.tsx
+++ b/src/components/overview/MacroCard.tsx
@@ -24,6 +24,7 @@ import { useApplicationContext } from '../../contexts/applicationContext'
 import { useSelectedCollection } from '../../contexts/selectors'
 import { mouseEnumLookup } from '../../maps/MouseMap'
 import { useCallback } from 'react'
+import { useMacroContext } from '../../contexts/macroContext'
 
 type Props = {
   macro: Macro
@@ -34,6 +35,7 @@ type Props = {
 export default function MacroCard({ macro, index, onDelete }: Props) {
   const { selection, onCollectionUpdate, changeSelectedMacroIndex } =
     useApplicationContext()
+  const { changeIsUpdatingMacro } = useMacroContext()
   const currentCollection = useSelectedCollection()
   const bg = useColorModeValue('stone.200', 'zinc.900')
   const secondBg = useColorModeValue('stone.300', 'zinc.800')
@@ -72,13 +74,8 @@ export default function MacroCard({ macro, index, onDelete }: Props) {
       {/** Top Row */}
       <HStack w="100%" justifyContent="space-between">
         <Flex w="100%" gap="8px" alignItems="center">
-          <Box
-            maxHeight="32px"
-          >
-            <em-emoji
-              shortcodes={macro.icon}
-              size="32px"
-            />
+          <Box maxHeight="32px">
+            <em-emoji shortcodes={macro.icon} size="32px" />
           </Box>
           <Text fontWeight="semibold">{macro.name}</Text>
         </Flex>
@@ -139,6 +136,7 @@ export default function MacroCard({ macro, index, onDelete }: Props) {
           variant="brand"
           leftIcon={<EditIcon />}
           onClick={() => {
+            changeIsUpdatingMacro(true)
             changeSelectedMacroIndex(index)
           }}
         >

--- a/src/components/overview/MacroList.tsx
+++ b/src/components/overview/MacroList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react'
 import { useCallback } from 'react'
 import { useApplicationContext } from '../../contexts/applicationContext'
+import { useMacroContext } from '../../contexts/macroContext'
 import { useSelectedCollection } from '../../contexts/selectors'
 import { ViewState } from '../../enums'
 import { Collection, Macro } from '../../types'
@@ -18,6 +19,7 @@ import MacroCard from './MacroCard'
 export default function MacroList() {
   const { selection, onCollectionUpdate, changeViewState } =
     useApplicationContext()
+  const { changeIsUpdatingMacro } = useMacroContext()
   const currentCollection: Collection = useSelectedCollection()
   const bg = useColorModeValue('stone.200', 'zinc.900')
   const shadowColour = useColorModeValue('md', 'white-md')
@@ -73,7 +75,10 @@ export default function MacroList() {
             leftIcon={<AddIcon />}
             size={['sm', 'md', 'lg']}
             maxW="50%"
-            onClick={() => changeViewState(ViewState.Addview)}
+            onClick={() => {
+              changeIsUpdatingMacro(false)
+              changeViewState(ViewState.Addview)
+            }}
           >
             Add Macro
           </Button>
@@ -103,7 +108,10 @@ export default function MacroList() {
                 }}
                 leftIcon={<AddIcon />}
                 size={['sm', 'md', 'lg']}
-                onClick={() => changeViewState(ViewState.Addview)}
+                onClick={() => {
+                  changeIsUpdatingMacro(false)
+                  changeViewState(ViewState.Addview)
+                }}
               >
                 Add Macro
               </Button>

--- a/src/contexts/macroContext.tsx
+++ b/src/contexts/macroContext.tsx
@@ -39,6 +39,7 @@ function MacroProvider({ children }: MacroProviderProps) {
   const [selectedElementId, setSelectedElementId] = useState<
     number | undefined
   >(undefined)
+    const [isUpdatingMacro, setIsUpdatingMacro] = useState(false)
   const currentMacro = useSelectedMacro()
   const currentCollection = useSelectedCollection()
   const { viewState, selection, onCollectionUpdate, changeSelectedMacroIndex } =
@@ -242,34 +243,20 @@ function MacroProvider({ children }: MacroProviderProps) {
     viewState
   ])
 
+    const changeIsUpdatingMacro = useCallback(
+      (newVal: boolean) => {
+        setIsUpdatingMacro(newVal)
+      },
+      [setIsUpdatingMacro]
+    )
+
   const value = useMemo<MacroState>(
     () => ({
       macro,
       sequence,
       ids,
       selectedElementId,
-      updateMacroName,
-      updateMacroIcon,
-      updateMacroType,
-      updateTrigger: updateTrigger,
-      updateAllowWhileOtherKeys,
-      onElementAdd,
-      onElementsAdd,
-      updateElement,
-      onElementDelete,
-      overwriteSequence,
-      onIdAdd,
-      onIdsAdd,
-      onIdDelete,
-      overwriteIds,
-      updateSelectedElementId,
-      updateMacro
-    }),
-    [
-      macro,
-      sequence,
-      ids,
-      selectedElementId,
+      isUpdatingMacro,
       updateMacroName,
       updateMacroIcon,
       updateMacroType,
@@ -285,7 +272,32 @@ function MacroProvider({ children }: MacroProviderProps) {
       onIdDelete,
       overwriteIds,
       updateSelectedElementId,
-      updateMacro
+      updateMacro,
+      changeIsUpdatingMacro
+    }),
+    [
+      macro,
+      sequence,
+      ids,
+      selectedElementId,
+      isUpdatingMacro,
+      updateMacroName,
+      updateMacroIcon,
+      updateMacroType,
+      updateTrigger,
+      updateAllowWhileOtherKeys,
+      onElementAdd,
+      onElementsAdd,
+      updateElement,
+      onElementDelete,
+      overwriteSequence,
+      onIdAdd,
+      onIdsAdd,
+      onIdDelete,
+      overwriteIds,
+      updateSelectedElementId,
+      updateMacro,
+      changeIsUpdatingMacro
     ]
   )
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,16 @@ import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
 import { theme } from './theme/index'
 import { ApplicationProvider } from './contexts/applicationContext'
 import { SettingsProvider } from './contexts/settingsContext'
+import { MacroProvider } from './contexts/macroContext'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <ChakraProvider theme={theme}>
     <ColorModeScript initialColorMode={theme.config.initialColorMode} />
     <ApplicationProvider>
       <SettingsProvider>
-        <App />
+        <MacroProvider>
+          <App />
+        </MacroProvider>
       </SettingsProvider>
     </ApplicationProvider>
   </ChakraProvider>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,6 +29,7 @@ export type MacroState = {
   sequence: ActionEventType[]
   ids: number[]
   selectedElementId: number | undefined
+  isUpdatingMacro: boolean
   updateMacroName: (newName: string) => void
   updateMacroIcon: (newIcon: string) => void
   updateMacroType: (newType: MacroType) => void
@@ -45,6 +46,7 @@ export type MacroState = {
   overwriteIds: (newArray: number[]) => void
   updateSelectedElementId: (newIndex: number | undefined) => void
   updateMacro: () => void
+  changeIsUpdatingMacro: (newVal: boolean) => void
 }
 
 export type SettingsState = {


### PR DESCRIPTION
Fixed issue where editing a macro required the user to change the macro name
Fixed issue where editing a collection did not let the user re-type the old name