### PR TITLE
fix for the failing icon build

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
       "active": true,
       "category": "DeveloperTool",
       "copyright": "",
+      "icon": ["icons/icon.ico"],
       "deb": {
         "depends": [
           "xserver-xorg-input-evdev",


### PR DESCRIPTION
Fix for the failing build as the icon file was not defined properly in tauri.conf.json.

Closes #61 