### PR TITLE
Allow CapsLock as a start trigger key

### DIFF
--- a/src/constants/HIDmap.ts
+++ b/src/constants/HIDmap.ts
@@ -6,6 +6,7 @@ export interface HidInfo {
   displayString: string
   webKeyId: string
   colSpan?: number
+  allowAtStartOfTrigger?: boolean
 }
 
 export class Hid {
@@ -437,10 +438,11 @@ export class Hid {
   static get CAPSLOCK(): HidInfo {
     return {
       HIDcode: 57,
-      category: HIDCategory.Modifier,
+      category: HIDCategory.Alphanumeric,
       displayString: 'Caps Lock',
       webKeyId: 'CapsLock',
-      colSpan: 2
+      colSpan: 2,
+      allowAtStartOfTrigger: true
     }
   }
   static get F1(): HidInfo {

--- a/src/constants/HIDmap.ts
+++ b/src/constants/HIDmap.ts
@@ -437,7 +437,7 @@ export class Hid {
   static get CAPSLOCK(): HidInfo {
     return {
       HIDcode: 57,
-      category: HIDCategory.Alphanumeric,
+      category: HIDCategory.Modifier,
       displayString: 'Caps Lock',
       webKeyId: 'CapsLock',
       colSpan: 2

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -58,6 +58,15 @@ export const checkIfModifierKey = (hid: number): boolean => {
   return HIDLookup.get(hid)?.category === HIDCategory.Modifier
 }
 
+export function checkIfKeyShouldContinueTriggerRecording(hid: number): boolean {
+  const hidEntry = HIDLookup.get(hid)
+  if (!hidEntry) return false
+  return (
+    hidEntry.category === HIDCategory.Modifier ||
+    hidEntry.allowAtStartOfTrigger === true
+  )
+}
+
 export const checkIfElementIsEditable = (element: ActionEventType): boolean => {
   if (element.type === 'SystemEventAction') {
     switch (element.data.type) {

--- a/src/hooks/useRecordingTrigger.ts
+++ b/src/hooks/useRecordingTrigger.ts
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useState } from 'react'
 import { MouseButton } from '../constants/enums'
 import { webCodeHIDLookup } from '../constants/HIDmap'
 import { webButtonLookup } from '../constants/MouseMap'
-import { checkIfModifierKey } from '../constants/utils'
+import {
+  checkIfModifierKey,
+  checkIfKeyShouldContinueTriggerRecording
+} from '../constants/utils'
 
 export default function useRecordingTrigger(
   initialItems: MouseButton | number[]
@@ -55,7 +58,7 @@ export default function useRecordingTrigger(
         return newItems
       })
 
-      if (!checkIfModifierKey(HIDcode)) stopRecording()
+      if (!checkIfKeyShouldContinueTriggerRecording(HIDcode)) stopRecording()
     },
     [stopRecording]
   )


### PR DESCRIPTION
This feature fixes an incorrect designation for capslock - allowing it to be set as a modifier and do ``capslock``+``W`` = ``arrowkeyup``

Closing #95 