### PR TITLE
Enhancement/drag elements from left panel

### DIFF
--- a/src/components/macroview/LeftAndCenterArea.tsx
+++ b/src/components/macroview/LeftAndCenterArea.tsx
@@ -1,0 +1,190 @@
+import { AspectRatio } from '@chakra-ui/react'
+import { useCallback, useState } from 'react'
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { restrictToWindowEdges } from '@dnd-kit/modifiers'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { KeyType } from '../../constants/enums'
+import { checkIfKeyboardKey, checkIfMouseEvent } from '../../constants/utils'
+import { useMacroContext } from '../../contexts/macroContext'
+import { useSettingsContext } from '../../contexts/settingsContext'
+import { ActiveInfo, ActionEventType } from '../../types'
+import SequencingArea from './centerPanel/SequencingArea'
+import OverlayDraggableWrapper from './leftPanel/OverlayDraggableWrapper'
+import SelectElementArea from './leftPanel/SelectElementArea'
+import SelectElementButton from './leftPanel/SelectElementButton'
+
+interface Props {
+  onOpenSettingsModal: () => void
+}
+
+export default function LeftAndCenterArea({ onOpenSettingsModal }: Props) {
+  const [activeId, setActiveId] = useState<number | undefined>(undefined)
+  const [activeInfo, setActiveInfo] = useState<ActiveInfo>(undefined)
+  const [ratioVal, setRatioVal] = useState<number | undefined>(undefined)
+  const [activeProperties, setActiveProperties] = useState<
+    ActionEventType | undefined
+  >(undefined)
+  const { sequence, onElementAdd, onElementsAdd } = useMacroContext()
+  const { config } = useSettingsContext()
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 2.5 }
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  )
+
+  const handleAddElement = useCallback(
+    (properties: ActionEventType) => {
+      if (config.AutoAddDelay) {
+        if (
+          sequence.at(-1)?.type !== 'DelayEventAction' &&
+          sequence.length > 0
+        ) {
+          onElementsAdd([
+            {
+              type: 'DelayEventAction',
+              data: config.DefaultDelayValue
+            },
+            properties
+          ])
+        } else {
+          onElementAdd(properties)
+        }
+      } else {
+        onElementAdd(properties)
+      }
+    },
+    [
+      config.AutoAddDelay,
+      config.DefaultDelayValue,
+      onElementAdd,
+      onElementsAdd,
+      sequence
+    ]
+  )
+
+  const calculateRatio = useCallback((info: ActiveInfo) => {
+    if (info === undefined) {
+      return
+    }
+    if (checkIfKeyboardKey(info)) {
+      return info.colSpan !== undefined ? info.colSpan / 1 : 1
+    } else {
+      return 2 / 0.75
+    }
+  }, [])
+
+  const getProperties = useCallback((info: ActiveInfo): ActionEventType => {
+    if (info === undefined) {
+      return {
+        type: 'KeyPressEventAction',
+        data: {
+          keypress: -1,
+          press_duration: 1,
+          keytype: KeyType[KeyType.DownUp]
+        }
+      }
+    }
+    if (checkIfKeyboardKey(info)) {
+      return {
+        type: 'KeyPressEventAction',
+        data: {
+          keypress: info.HIDcode,
+          press_duration: 1,
+          keytype: KeyType[KeyType.DownUp]
+        }
+      }
+    } else if (checkIfMouseEvent(info)) {
+      return {
+        type: 'MouseEventAction',
+        data: {
+          type: 'Press',
+          data: {
+            type: 'DownUp',
+            button: info.enumVal,
+            duration: 20
+          }
+        }
+      }
+    } else {
+      return {
+        type: 'SystemEventAction',
+        data: info.defaultData
+      }
+    }
+  }, [])
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { over } = event
+
+      if (activeProperties && over && over.id === 'sortableList') {
+        handleAddElement(activeProperties)
+      }
+      setActiveId(undefined)
+      setRatioVal(undefined)
+      setActiveProperties(undefined)
+    },
+    [activeProperties, handleAddElement]
+  )
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const { active } = event
+
+      if (active.data.current) {
+        setActiveInfo(active.data.current.info)
+        setRatioVal(calculateRatio(active.data.current.info))
+        setActiveProperties(getProperties(active.data.current.info))
+      }
+      setActiveId(Number(active.id))
+    },
+    [calculateRatio, getProperties]
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <SelectElementArea />
+      <SequencingArea onOpenSettingsModal={onOpenSettingsModal} />
+      <DragOverlay zIndex={2} modifiers={[restrictToWindowEdges]}>
+        {activeInfo && activeId ? (
+          <OverlayDraggableWrapper
+            id={activeInfo.displayString}
+            info={activeInfo}
+          >
+            <AspectRatio ratio={ratioVal ?? 1}>
+              <SelectElementButton
+                nameText={activeInfo.displayString}
+                properties={
+                  activeProperties ?? {
+                    type: 'KeyPressEventAction',
+                    data: {
+                      keypress: -1,
+                      press_duration: 1,
+                      keytype: KeyType[KeyType.DownUp]
+                    }
+                  }
+                }
+              />
+            </AspectRatio>
+          </OverlayDraggableWrapper>
+        ) : undefined}
+      </DragOverlay>
+    </DndContext>
+  )
+}

--- a/src/components/macroview/centerPanel/DroppableWrapper.tsx
+++ b/src/components/macroview/centerPanel/DroppableWrapper.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react'
+import { useDroppable } from '@dnd-kit/core'
+import { Box } from '@chakra-ui/react'
+
+interface Props {
+  id: string
+  children: ReactNode
+}
+
+export default function DroppableWrapper({ id, children }: Props) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: id
+  })
+  const style = {
+    backgroundColor: isOver ? '#80808055' : 'transparent',
+    transition: 'background-color 300ms ease-out'
+  }
+
+  return (
+    <Box
+      w="full"
+      ref={setNodeRef}
+      style={style}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/components/macroview/centerPanel/DroppableWrapper.tsx
+++ b/src/components/macroview/centerPanel/DroppableWrapper.tsx
@@ -19,6 +19,11 @@ export default function DroppableWrapper({ id, children }: Props) {
   return (
     <Box
       w="full"
+      h={{
+        base: 'calc(100% - 84px)',
+        sm: 'calc(100% - 100px)',
+        md: 'calc(100% - 108px)'
+      }}
       ref={setNodeRef}
       style={style}
     >

--- a/src/components/macroview/centerPanel/SequencingArea.tsx
+++ b/src/components/macroview/centerPanel/SequencingArea.tsx
@@ -14,7 +14,7 @@ import {
 } from '@chakra-ui/react'
 import { DeleteIcon, SettingsIcon, TimeIcon } from '@chakra-ui/icons'
 import { useCallback } from 'react'
-import { Keypress, MousePressAction } from '../../../types'
+import { UserInputType } from '../../../types'
 import { useMacroContext } from '../../../contexts/macroContext'
 import useRecordingSequence from '../../../hooks/useRecordingSequence'
 import { useSettingsContext } from '../../../contexts/settingsContext'
@@ -23,6 +23,7 @@ import { checkIfKeypress, checkIfMouseButton } from '../../../constants/utils'
 import ClearSequenceModal from './ClearSequenceModal'
 import { RecordIcon, StopIcon } from '../../icons'
 import SortableList from './SortableList'
+import DroppableWrapper from './DroppableWrapper'
 
 interface Props {
   onOpenSettingsModal: () => void
@@ -41,8 +42,8 @@ export default function SequencingArea({ onOpenSettingsModal }: Props) {
 
   const onItemChanged = useCallback(
     (
-      item: Keypress | MousePressAction | undefined,
-      prevItem: Keypress | MousePressAction | undefined,
+      item: UserInputType,
+      prevItem: UserInputType,
       timeDiff: number,
       isUpEvent: boolean
     ) => {
@@ -211,7 +212,9 @@ export default function SequencingArea({ onOpenSettingsModal }: Props) {
         stopRecording={stopRecording}
       />
       <Divider w="full" />
-      <SortableList recording={recording} stopRecording={stopRecording} />
+      <DroppableWrapper id="sortableList">
+        <SortableList recording={recording} stopRecording={stopRecording} />
+      </DroppableWrapper>
     </VStack>
   )
 }

--- a/src/components/macroview/centerPanel/SortableList.tsx
+++ b/src/components/macroview/centerPanel/SortableList.tsx
@@ -20,7 +20,7 @@ import {
 import { useCallback, useState } from 'react'
 import { useMacroContext } from '../../../contexts/macroContext'
 import useScrollbarStyles from '../../../hooks/useScrollbarStyles'
-import DragWrapper from './sortableElement/DragWrapper'
+import SortableDragWrapper from './sortableElement/SortableDragWrapper'
 import SortableItem from './sortableElement/SortableItem'
 import SortableWrapper from './sortableElement/SortableWrapper'
 
@@ -77,9 +77,9 @@ export default function SortableList({ recording, stopRecording }: Props) {
       <SortableContext items={ids} strategy={verticalListSortingStrategy}>
         <VStack
           w="full"
-          h="full"
+          h="100vh"
           px={4}
-          pb={4}
+          py={2}
           overflowY="auto"
           overflowX="hidden"
           sx={useScrollbarStyles()}
@@ -100,16 +100,16 @@ export default function SortableList({ recording, stopRecording }: Props) {
           ))}
         </VStack>
       </SortableContext>
-      <DragOverlay>
+      <DragOverlay zIndex={1}>
         {activeId ? (
-          <DragWrapper id={activeId} element={sequence[activeId - 1]}>
+          <SortableDragWrapper id={activeId} element={sequence[activeId - 1]}>
             <SortableItem
               id={activeId}
               element={sequence[activeId - 1]}
               recording={recording}
               stopRecording={stopRecording}
             />
-          </DragWrapper>
+          </SortableDragWrapper>
         ) : undefined}
       </DragOverlay>
     </DndContext>

--- a/src/components/macroview/centerPanel/SortableList.tsx
+++ b/src/components/macroview/centerPanel/SortableList.tsx
@@ -77,7 +77,7 @@ export default function SortableList({ recording, stopRecording }: Props) {
       <SortableContext items={ids} strategy={verticalListSortingStrategy}>
         <VStack
           w="full"
-          h="100vh"
+          h="full"
           px={4}
           py={2}
           overflowY="auto"

--- a/src/components/macroview/centerPanel/sortableElement/SortableDragWrapper.tsx
+++ b/src/components/macroview/centerPanel/sortableElement/SortableDragWrapper.tsx
@@ -11,7 +11,7 @@ interface Props {
   children: ReactNode
 }
 
-export default function DragWrapper({ id, element, children }: Props) {
+export default function SortableDragWrapper({ id, element, children }: Props) {
   const { selectedElementId } = useMacroContext()
 
   const bg = useMainBgColour()

--- a/src/components/macroview/leftPanel/AccordionComponents/KeyboardKeysSection.tsx
+++ b/src/components/macroview/leftPanel/AccordionComponents/KeyboardKeysSection.tsx
@@ -12,6 +12,7 @@ import { KeyType } from '../../../../constants/enums'
 import { HidInfo } from '../../../../constants/HIDmap'
 import { KeyboardKeyCategory } from '../../../../types'
 import { KeyboardIcon } from '../../../icons'
+import DraggableWrapper from '../DraggableWrapper'
 import SelectElementButton from '../SelectElementButton'
 
 interface Props {
@@ -53,24 +54,25 @@ export default function KeyboardKeysSection({ keyboardKeyCategories }: Props) {
             >
               {category.elements.map((HIDinfo: HidInfo) => (
                 <GridItem colSpan={HIDinfo.colSpan ?? 1} key={HIDinfo.HIDcode}>
-                  <AspectRatio
-                    h="full"
-                    ratio={
-                      HIDinfo.colSpan !== undefined ? HIDinfo.colSpan / 1 : 1
-                    }
-                  >
-                    <SelectElementButton
-                      nameText={HIDinfo.displayString}
-                      properties={{
-                        type: 'KeyPressEventAction',
-                        data: {
-                          keypress: HIDinfo.HIDcode,
-                          press_duration: 1,
-                          keytype: KeyType[KeyType.DownUp]
-                        }
-                      }}
-                    />
-                  </AspectRatio>
+                  <DraggableWrapper id={HIDinfo.HIDcode} info={HIDinfo}>
+                    <AspectRatio
+                      ratio={
+                        HIDinfo.colSpan !== undefined ? HIDinfo.colSpan / 1 : 1
+                      }
+                    >
+                      <SelectElementButton
+                        nameText={HIDinfo.displayString}
+                        properties={{
+                          type: 'KeyPressEventAction',
+                          data: {
+                            keypress: HIDinfo.HIDcode,
+                            press_duration: 1,
+                            keytype: KeyType[KeyType.DownUp]
+                          }
+                        }}
+                      />
+                    </AspectRatio>
+                  </DraggableWrapper>
                 </GridItem>
               ))}
             </Grid>

--- a/src/components/macroview/leftPanel/AccordionComponents/MouseButtonsSection.tsx
+++ b/src/components/macroview/leftPanel/AccordionComponents/MouseButtonsSection.tsx
@@ -9,6 +9,7 @@ import {
 } from '@chakra-ui/react'
 import { MouseInputInfo } from '../../../../constants/MouseMap'
 import { MouseIcon } from '../../../icons'
+import DraggableWrapper from '../DraggableWrapper'
 import SelectElementButton from '../SelectElementButton'
 
 interface Props {
@@ -45,22 +46,28 @@ export default function MouseButtonsSection({ elementsToRender }: Props) {
           spacing={2}
         >
           {elementsToRender.map((info: MouseInputInfo) => (
-            <AspectRatio ratio={2 / 0.75} key={info.webButtonVal}>
-              <SelectElementButton
-                nameText={info.displayString}
-                properties={{
-                  type: 'MouseEventAction',
-                  data: {
-                    type: 'Press',
+            <DraggableWrapper
+              id={info.enumVal}
+              info={info}
+              key={info.enumVal}
+            >
+              <AspectRatio ratio={2 / 0.75} key={info.enumVal}>
+                <SelectElementButton
+                  nameText={info.displayString}
+                  properties={{
+                    type: 'MouseEventAction',
                     data: {
-                      type: 'DownUp',
-                      button: info.enumVal,
-                      duration: 20
+                      type: 'Press',
+                      data: {
+                        type: 'DownUp',
+                        button: info.enumVal,
+                        duration: 20
+                      }
                     }
-                  }
-                }}
-              />
-            </AspectRatio>
+                  }}
+                />
+              </AspectRatio>
+            </DraggableWrapper>
           ))}
         </SimpleGrid>
       </AccordionPanel>

--- a/src/components/macroview/leftPanel/AccordionComponents/SystemEventsSection.tsx
+++ b/src/components/macroview/leftPanel/AccordionComponents/SystemEventsSection.tsx
@@ -45,9 +45,9 @@ export default function SystemEventsSection({ elementsToRender }: Props) {
           px={4}
           spacing={2}
         >
-          {elementsToRender.map((info: SystemEventInfo, index:number) => (
+          {elementsToRender.map((info: SystemEventInfo, index: number) => (
             <DraggableWrapper
-              id={300 + index} // using a string ID causes lag, this is arbitrary to ensure no overlap with keyboard keys / mouse buttons
+              id={300 + index} // using a string ID causes lag (unsure why). 300 is an arbitrary value, but high enough to ensure no overlap with Hid codes / mouse buttons codes
               info={info}
               key={info.displayString}
             >

--- a/src/components/macroview/leftPanel/AccordionComponents/SystemEventsSection.tsx
+++ b/src/components/macroview/leftPanel/AccordionComponents/SystemEventsSection.tsx
@@ -9,6 +9,7 @@ import {
 } from '@chakra-ui/react'
 import { SystemEventInfo } from '../../../../constants/SystemEventMap'
 import { SystemIcon } from '../../../icons'
+import DraggableWrapper from '../DraggableWrapper'
 import SelectElementButton from '../SelectElementButton'
 
 interface Props {
@@ -44,18 +45,24 @@ export default function SystemEventsSection({ elementsToRender }: Props) {
           px={4}
           spacing={2}
         >
-          {elementsToRender.map((info: SystemEventInfo) => (
-            <AspectRatio ratio={2 / 0.75} key={info.displayString}>
-              <SelectElementButton
+          {elementsToRender.map((info: SystemEventInfo, index:number) => (
+            <DraggableWrapper
+              id={300 + index} // using a string ID causes lag, this is arbitrary to ensure no overlap with keyboard keys / mouse buttons
+              info={info}
               key={info.displayString}
-                nameText={info.displayString}
-                descText={info.description}
-                properties={{
-                  type: 'SystemEventAction',
-                  data: info.defaultData
-                }}
-              />
-            </AspectRatio>
+            >
+              <AspectRatio ratio={2 / 0.75} key={info.displayString}>
+                <SelectElementButton
+                  key={info.displayString}
+                  nameText={info.displayString}
+                  descText={info.description}
+                  properties={{
+                    type: 'SystemEventAction',
+                    data: info.defaultData
+                  }}
+                />
+              </AspectRatio>
+            </DraggableWrapper>
           ))}
         </SimpleGrid>
       </AccordionPanel>

--- a/src/components/macroview/leftPanel/DraggableWrapper.tsx
+++ b/src/components/macroview/leftPanel/DraggableWrapper.tsx
@@ -1,0 +1,37 @@
+import { Box } from '@chakra-ui/react'
+import { useDraggable } from '@dnd-kit/core'
+import { ReactNode } from 'react'
+import { HidInfo } from '../../../constants/HIDmap'
+import { MouseInputInfo } from '../../../constants/MouseMap'
+import { SystemEventInfo } from '../../../constants/SystemEventMap'
+
+interface Props {
+  id: number | string
+  info: HidInfo | SystemEventInfo | MouseInputInfo
+  children: ReactNode
+}
+
+export default function DraggableWrapper({ id, info, children }: Props) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: id,
+    data: {
+        info: info
+    }
+  })
+  const style = transform
+    ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`
+      }
+    : undefined
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/components/macroview/leftPanel/OverlayDraggableWrapper.tsx
+++ b/src/components/macroview/leftPanel/OverlayDraggableWrapper.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@chakra-ui/react'
+import { ReactNode } from 'react'
+import { HidInfo } from '../../../constants/HIDmap'
+import { MouseInputInfo } from '../../../constants/MouseMap'
+import { SystemEventInfo } from '../../../constants/SystemEventMap'
+
+interface Props {
+  id: number | string
+  info: HidInfo | SystemEventInfo | MouseInputInfo
+  children: ReactNode
+}
+
+export default function OverlayDraggableWrapper({ id, info, children }: Props) {
+  return <Box>{children}</Box>
+}

--- a/src/components/macroview/leftPanel/SelectElementButton.tsx
+++ b/src/components/macroview/leftPanel/SelectElementButton.tsx
@@ -6,8 +6,8 @@ import { ActionEventType } from '../../../types'
 
 interface Props {
   properties: ActionEventType
-  nameText: string,
-  descText?: string,
+  nameText: string
+  descText?: string
 }
 
 export default function SelectElementButton({
@@ -51,7 +51,12 @@ export default function SelectElementButton({
   ])
 
   return (
-    <Tooltip label={descText === "" ? "" : descText} hasArrow variant="brandSecondary" textAlign="center">
+    <Tooltip
+      label={descText === '' ? '' : descText}
+      hasArrow
+      variant="brandSecondary"
+      textAlign="center"
+    >
       <Box
         w="full"
         h="full"
@@ -66,16 +71,16 @@ export default function SelectElementButton({
         onClick={handleAddElement}
         transition="ease-out 150ms"
       >
-          <Text
-            w="full"
-            fontWeight="semibold"
-            fontSize={['xs', 'sm', 'md']}
-            cursor="pointer"
-            overflowWrap="normal"
-            wordBreak="break-word"
-          >
-            {nameText}
-          </Text>
+        <Text
+          w="full"
+          fontWeight="semibold"
+          fontSize={['xs', 'sm', 'md']}
+          cursor="pointer"
+          overflowWrap="normal"
+          wordBreak="break-word"
+        >
+          {nameText}
+        </Text>
       </Box>
     </Tooltip>
   )

--- a/src/components/macroview/rightPanel/EditArea.tsx
+++ b/src/components/macroview/rightPanel/EditArea.tsx
@@ -1,4 +1,5 @@
 import { VStack, Text } from '@chakra-ui/react'
+import { AnimatePresence } from 'framer-motion'
 import { useMemo } from 'react'
 import { useMacroContext } from '../../../contexts/macroContext'
 import { useSelectedElement } from '../../../contexts/selectors'
@@ -64,7 +65,7 @@ export default function EditArea() {
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         Edit Element
       </Text>
-      {SelectedElementFormComponent}
+      <AnimatePresence>{SelectedElementFormComponent}</AnimatePresence>
     </VStack>
   )
 }

--- a/src/components/macroview/rightPanel/editForms/ClipboardForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/ClipboardForm.tsx
@@ -4,13 +4,15 @@ import {
   Text,
   HStack,
   Box,
-  useColorMode
+  useColorMode,
+  VStack
 } from '@chakra-ui/react'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useMacroContext } from '../../../../contexts/macroContext'
 import data from '@emoji-mart/data'
 import Picker from '@emoji-mart/react'
 import { SystemEventAction } from '../../../../types'
+import { motion } from 'framer-motion'
 
 interface Props {
   selectedElementId: number
@@ -103,32 +105,42 @@ export default function ClipboardForm({
   )
 
   return (
-    <>
+    <VStack
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      w="full"
+      gap={2}
+    >
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         Paste Text
       </Text>
       <Divider />
-      <HStack w="full" justifyContent="space-between">
-        <Text fontSize={['xs', 'sm', 'md']} fontWeight="semibold">
-          Text to paste
-        </Text>
-        <Box
-          filter={showEmojiPicker ? 'grayscale(0%)' : 'grayscale(100%)'}
-          _hover={{ filter: 'grayscale(0%)', transform: 'scale(110%)' }}
-          transition="ease-out 150ms"
-          onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-          id="emoji-button"
-        >
-          <em-emoji id="smile" size="32px" />
-        </Box>
-      </HStack>
-      <Textarea
-        variant="brandAccent"
-        value={text}
-        onChange={onTextChange}
-        onBlur={onInputBlur}
-        placeholder="e.g. glhf <3"
-      />
+      <VStack w="full">
+        <HStack w="full" justifyContent="space-between">
+          <Text fontSize={['xs', 'sm', 'md']} fontWeight="semibold">
+            Text to paste
+          </Text>
+          <Box
+            filter={showEmojiPicker ? 'grayscale(0%)' : 'grayscale(100%)'}
+            _hover={{ filter: 'grayscale(0%)', transform: 'scale(110%)' }}
+            transition="ease-out 150ms"
+            cursor="pointer"
+            onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+            id="emoji-button"
+          >
+            <em-emoji id="smile" size="32px" />
+          </Box>
+        </HStack>
+        <Textarea
+          variant="brandAccent"
+          value={text}
+          onChange={onTextChange}
+          onBlur={onInputBlur}
+          placeholder="e.g. glhf <3"
+        />
+      </VStack>
       {showEmojiPicker && (
         <Box ref={pickerRef} w="full">
           <Picker
@@ -143,6 +155,6 @@ export default function ClipboardForm({
         </Box>
         // TODO: need to figure out how to adjust height of picker, as it doesn't allow for customizing style. Maybe it will be updated one day or we find a different emoji picker
       )}
-    </>
+    </VStack>
   )
 }

--- a/src/components/macroview/rightPanel/editForms/DelayForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/DelayForm.tsx
@@ -1,4 +1,5 @@
-import { Divider, Grid, GridItem, Input, Button, Text } from '@chakra-ui/react'
+import { Divider, Grid, GridItem, Input, Button, Text, VStack } from '@chakra-ui/react'
+import { motion } from 'framer-motion'
 import { useCallback, useEffect, useState } from 'react'
 import { useMacroContext } from '../../../../contexts/macroContext'
 import { useSettingsContext } from '../../../../contexts/settingsContext'
@@ -69,7 +70,14 @@ export default function DelayForm({
   ])
 
   return (
-    <>
+    <VStack
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      w="full"
+      gap={2}
+    >
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         Delay Element
       </Text>
@@ -92,6 +100,6 @@ export default function DelayForm({
       <Button variant="brand" w="fit-content" onClick={resetDuration}>
         Set to Default
       </Button>
-    </>
+    </VStack>
   )
 }

--- a/src/components/macroview/rightPanel/editForms/EmptyForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/EmptyForm.tsx
@@ -1,8 +1,18 @@
 import { Flex, Text } from '@chakra-ui/react'
+import { motion } from 'framer-motion'
 
 export default function EmptyForm() {
   return (
-    <Flex h="100vh" justifyContent="center" alignItems="center">
+    <Flex
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      w="full"
+      h="100vh"
+      justifyContent="center"
+      alignItems="center"
+    >
       <Text
         fontWeight="bold"
         fontSize={['sm', 'md', 'lg']}

--- a/src/components/macroview/rightPanel/editForms/KeyPressForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/KeyPressForm.tsx
@@ -5,7 +5,8 @@ import {
   Flex,
   Button,
   Input,
-  Text
+  Text,
+  VStack
 } from '@chakra-ui/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useMacroContext } from '../../../../contexts/macroContext'
@@ -13,6 +14,7 @@ import { KeyType } from '../../../../constants/enums'
 import { HIDLookup } from '../../../../constants/HIDmap'
 import { DownArrowIcon, DownUpArrowsIcon, UpArrowIcon } from '../../../icons'
 import { KeyPressEventAction } from '../../../../types'
+import { motion } from 'framer-motion'
 
 interface Props {
   selectedElementId: number
@@ -24,7 +26,7 @@ export default function KeyPressForm({
   selectedElement
 }: Props) {
   const [headingText, setHeadingText] = useState('')
-  const [keypressDuration, setKeypressDuration] = useState("1")
+  const [keypressDuration, setKeypressDuration] = useState('1')
   const [keypressType, setKeypressType] = useState<KeyType>()
   const { updateElement } = useMacroContext()
 
@@ -53,9 +55,8 @@ export default function KeyPressForm({
   const onInputBlur = useCallback(() => {
     let duration
     if (keypressDuration === '') {
-      duration = 0;
+      duration = 0
     } else {
-
       duration = parseInt(keypressDuration)
       if (Number.isNaN(duration)) {
         return
@@ -82,7 +83,14 @@ export default function KeyPressForm({
   )
 
   return (
-    <>
+    <VStack
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      w="full"
+      gap={2}
+    >
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         {headingText}
       </Text>
@@ -156,6 +164,6 @@ export default function KeyPressForm({
           </GridItem>
         </Grid>
       )}
-    </>
+    </VStack>
   )
 }

--- a/src/components/macroview/rightPanel/editForms/MousePressForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/MousePressForm.tsx
@@ -5,7 +5,8 @@ import {
   Flex,
   Button,
   Input,
-  Text
+  Text,
+  VStack
 } from '@chakra-ui/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useMacroContext } from '../../../../contexts/macroContext'
@@ -13,6 +14,7 @@ import { KeyType } from '../../../../constants/enums'
 import { mouseEnumLookup } from '../../../../constants/MouseMap'
 import { DownArrowIcon, DownUpArrowsIcon, UpArrowIcon } from '../../../icons'
 import { MouseEventAction } from '../../../../types'
+import { motion } from 'framer-motion'
 
 interface Props {
   selectedElementId: number
@@ -24,7 +26,7 @@ export default function MousePressForm({
   selectedElement
 }: Props) {
   const [headingText, setHeadingText] = useState('')
-  const [mousepressDuration, setMousepressDuration] = useState("1")
+  const [mousepressDuration, setMousepressDuration] = useState('1')
   const [mousepressType, setMousepressType] = useState<KeyType>()
   const { updateElement } = useMacroContext()
 
@@ -42,7 +44,6 @@ export default function MousePressForm({
 
   const onMousepressDurationChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-
       setMousepressDuration(event.target.value)
     },
     [setMousepressDuration]
@@ -54,9 +55,8 @@ export default function MousePressForm({
     }
     let duration
     if (mousepressDuration === '') {
-      duration = 0;
+      duration = 0
     } else {
-
       duration = parseInt(mousepressDuration)
       if (Number.isNaN(duration)) {
         return
@@ -116,7 +116,14 @@ export default function MousePressForm({
   )
 
   return (
-    <>
+    <VStack
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      w="full"
+      gap={2}
+    >
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         {headingText}
       </Text>
@@ -190,6 +197,6 @@ export default function MousePressForm({
           </GridItem>
         </Grid>
       )}
-    </>
+    </VStack>
   )
 }

--- a/src/components/macroview/rightPanel/editForms/OpenEventForm.tsx
+++ b/src/components/macroview/rightPanel/editForms/OpenEventForm.tsx
@@ -4,6 +4,7 @@ import { useMacroContext } from '../../../../contexts/macroContext'
 import { open } from '@tauri-apps/api/dialog'
 import { sysEventLookup } from '../../../../constants/SystemEventMap'
 import { SystemEventAction } from '../../../../types'
+import { motion } from 'framer-motion'
 
 interface Props {
   selectedElement: SystemEventAction
@@ -104,22 +105,32 @@ export default function OpenEventForm({
   )
 
   return (
-    <VStack textAlign="left" w="full">
+    <VStack
+      as={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      textAlign="left"
+      w="full"
+      gap={2}
+    >
       <Text w="full" fontWeight="semibold" fontSize={['sm', 'md']}>
         {headerText}
       </Text>
       <Divider />
-      <Text w="full" fontSize={['xs', 'sm', 'md']} fontWeight="semibold">
-        {subHeaderText}
-      </Text>
-      <Textarea
-        variant="brand"
-        value={path}
-        onChange={onPathChange}
-        onBlur={onInputBlur}
-        placeholder="path"
-        isDisabled={subtype === 'File' || subtype === 'Directory'}
-      />
+      <VStack w="full">
+        <Text w="full" fontSize={['xs', 'sm', 'md']} fontWeight="semibold">
+          {subHeaderText}
+        </Text>
+        <Textarea
+          variant="brand"
+          value={path}
+          onChange={onPathChange}
+          onBlur={onInputBlur}
+          placeholder="path"
+          isDisabled={subtype === 'File' || subtype === 'Directory'}
+        />
+      </VStack>
       {subtype === 'File' && (
         <Button
           variant="brandAccent"

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -2,14 +2,16 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { HIDCategory, MouseButton } from './enums'
 import {
   ActionEventType,
+  ActiveInfo,
   ApplicationConfig,
   Collection,
   Keypress,
   MacroData,
-  MousePressAction
+  MousePressAction,
+  UserInputType
 } from '../types'
-import { HIDLookup } from './HIDmap'
-import { mouseEnumLookup } from './MouseMap'
+import { HidInfo, HIDLookup } from './HIDmap'
+import { mouseEnumLookup, MouseInputInfo } from './MouseMap'
 import { sysEventLookup } from './SystemEventMap'
 
 export const updateBackendConfig = (
@@ -37,16 +39,18 @@ export const checkIfMouseButtonArray = (
   )
 }
 
-export const checkIfKeypress = (
-  e: Keypress | MousePressAction | undefined
-): e is Keypress => {
+export const checkIfKeypress = (e: UserInputType): e is Keypress => {
   return (e as Keypress).keypress !== undefined
 }
 
-export const checkIfMouseButton = (
-  e: Keypress | MousePressAction | undefined
-): e is MousePressAction => {
+export const checkIfMouseButton = (e: UserInputType): e is MousePressAction => {
   return (e as MousePressAction).button !== undefined
+}
+export const checkIfKeyboardKey = (e: ActiveInfo): e is HidInfo => {
+  return (e as HidInfo).category !== undefined
+}
+export const checkIfMouseEvent = (e: ActiveInfo): e is MouseInputInfo => {
+  return (e as MouseInputInfo).enumVal !== undefined
 }
 
 /** Currently unused, if Macro types are added back this can probably be refactored elsewhere */

--- a/src/contexts/macroContext.tsx
+++ b/src/contexts/macroContext.tsx
@@ -145,12 +145,7 @@ function MacroProvider({ children }: MacroProviderProps) {
     }
 
     return true
-  }, [
-    macro.trigger.data,
-    macro.trigger.type,
-    sequence.length,
-    willCauseTriggerLooping
-  ])
+  }, [macro.trigger.data, macro.trigger.type, sequence.length])
 
   useEffect(() => {
     if (currentMacro === undefined) {

--- a/src/hooks/useRecordingSequence.ts
+++ b/src/hooks/useRecordingSequence.ts
@@ -3,24 +3,20 @@ import { useCallback, useEffect, useState } from 'react'
 import { KeyType } from '../constants/enums'
 import { webCodeHIDLookup } from '../constants/HIDmap'
 import { webButtonLookup } from '../constants/MouseMap'
-import { Keypress, MousePressAction } from '../types'
-import {error} from "tauri-plugin-log"
+import { Keypress, MousePressAction, UserInputType } from '../types'
+import { error } from 'tauri-plugin-log'
 
 export default function useRecordingSequence(
   onItemChanged: (
-    item: Keypress | MousePressAction | undefined,
-    prevItem: Keypress | MousePressAction | undefined,
+    item: UserInputType,
+    prevItem: UserInputType,
     timeDiff: number,
     isUpEvent: boolean
   ) => void
 ) {
   const [recording, setRecording] = useState(false)
-  const [item, setItem] = useState<Keypress | MousePressAction | undefined>(
-    undefined
-  )
-  const [prevItem, setPrevItem] = useState<
-    Keypress | MousePressAction | undefined
-  >(undefined)
+  const [item, setItem] = useState<UserInputType>(undefined)
+  const [prevItem, setPrevItem] = useState<UserInputType>(undefined)
   const [eventType, setEventType] = useState<'Down' | 'Up'>('Down')
   const [prevEventType, setPrevEventType] = useState<'Down' | 'Up'>('Down')
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -198,3 +198,5 @@ export interface PluginCategory {
   name: string
   elements: PluginEventInfo[]
 }
+export type ActiveInfo = HidInfo | SystemEventInfo | MouseInputInfo | undefined
+export type UserInputType = Keypress | MousePressAction | undefined

--- a/src/views/Macroview.tsx
+++ b/src/views/Macroview.tsx
@@ -1,10 +1,28 @@
-import { VStack, HStack } from '@chakra-ui/react'
+import { VStack, HStack, AspectRatio } from '@chakra-ui/react'
 import EditArea from '../components/macroview/rightPanel/EditArea'
 import SelectElementArea from '../components/macroview/leftPanel/SelectElementArea'
 import SequencingArea from '../components/macroview/centerPanel/SequencingArea'
 import Header from '../components/macroview/topArea/Header'
 import { useMacroContext } from '../contexts/macroContext'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import SelectElementButton from '../components/macroview/leftPanel/SelectElementButton'
+import { ActionEventType, ActiveInfo } from '../types'
+import { checkIfKeyboardKey, checkIfMouseEvent } from '../constants/utils'
+import { KeyType } from '../constants/enums'
+import { restrictToWindowEdges } from '@dnd-kit/modifiers'
+import { useSettingsContext } from '../contexts/settingsContext'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import OverlayDraggableWrapper from '../components/macroview/leftPanel/OverlayDraggableWrapper'
 
 type Props = {
   isEditing: boolean
@@ -13,10 +31,134 @@ type Props = {
 
 export default function Macroview({ isEditing, onOpenSettingsModal }: Props) {
   const { changeIsUpdatingMacro } = useMacroContext()
+  const [activeId, setActiveId] = useState<number | undefined>(undefined)
+  const [activeInfo, setActiveInfo] = useState<ActiveInfo>(undefined)
+  const [ratioVal, setRatioVal] = useState<number | undefined>(undefined)
+  const [activeProperties, setActiveProperties] = useState<
+    ActionEventType | undefined
+  >(undefined)
+  const { sequence, onElementAdd, onElementsAdd } = useMacroContext()
+  const { config } = useSettingsContext()
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 2.5 }
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  )
 
   useEffect(() => {
     changeIsUpdatingMacro(isEditing)
   }, [changeIsUpdatingMacro, isEditing])
+
+  const handleAddElement = useCallback(
+    (properties: ActionEventType) => {
+      if (config.AutoAddDelay) {
+        if (
+          sequence.at(-1)?.type !== 'DelayEventAction' &&
+          sequence.length > 0
+        ) {
+          onElementsAdd([
+            {
+              type: 'DelayEventAction',
+              data: config.DefaultDelayValue
+            },
+            properties
+          ])
+        } else {
+          onElementAdd(properties)
+        }
+      } else {
+        onElementAdd(properties)
+      }
+    },
+    [
+      config.AutoAddDelay,
+      config.DefaultDelayValue,
+      onElementAdd,
+      onElementsAdd,
+      sequence
+    ]
+  )
+
+  const calculateRatio = useCallback((info: ActiveInfo) => {
+    if (info === undefined) {
+      return
+    }
+    if (checkIfKeyboardKey(info)) {
+      return info.colSpan !== undefined ? info.colSpan / 1 : 1
+    } else {
+      return 2 / 0.75
+    }
+  }, [])
+
+  const getProperties = useCallback((info: ActiveInfo): ActionEventType => {
+    if (info === undefined) {
+      return {
+        type: 'KeyPressEventAction',
+        data: {
+          keypress: -1,
+          press_duration: 1,
+          keytype: KeyType[KeyType.DownUp]
+        }
+      }
+    }
+    if (checkIfKeyboardKey(info)) {
+      return {
+        type: 'KeyPressEventAction',
+        data: {
+          keypress: info.HIDcode,
+          press_duration: 1,
+          keytype: KeyType[KeyType.DownUp]
+        }
+      }
+    } else if (checkIfMouseEvent(info)) {
+      return {
+        type: 'MouseEventAction',
+        data: {
+          type: 'Press',
+          data: {
+            type: 'DownUp',
+            button: info.enumVal,
+            duration: 20
+          }
+        }
+      }
+    } else {
+      return {
+        type: 'SystemEventAction',
+        data: info.defaultData
+      }
+    }
+  }, [])
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { over } = event
+      if (activeProperties && over && over.id === 'sortableList') {
+        handleAddElement(activeProperties)
+      }
+      setActiveId(undefined)
+      setRatioVal(undefined)
+      setActiveProperties(undefined)
+    },
+    [activeProperties, handleAddElement]
+  )
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const { active } = event
+      if (active.data.current) {
+        setActiveInfo(active.data.current.info)
+        setRatioVal(calculateRatio(active.data.current.info))
+        setActiveProperties(getProperties(active.data.current.info))
+      }
+      setActiveId(Number(active.id))
+    },
+    [calculateRatio, getProperties]
+  )
+
   return (
     <VStack h="full" spacing="0px" overflow="hidden">
       {/** Top Header */}
@@ -31,8 +173,38 @@ export default function Macroview({ isEditing, onOpenSettingsModal }: Props) {
         spacing="0"
       >
         {/** Bottom Panels */}
-        <SelectElementArea />
-        <SequencingArea onOpenSettingsModal={onOpenSettingsModal} />
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+        >
+          <SelectElementArea />
+          <SequencingArea onOpenSettingsModal={onOpenSettingsModal} />
+          <DragOverlay zIndex={2} modifiers={[restrictToWindowEdges]}>
+            {activeInfo && activeId ? (
+              <OverlayDraggableWrapper
+                id={activeInfo.displayString}
+                info={activeInfo}
+              >
+                <AspectRatio ratio={ratioVal ?? 1}>
+                  <SelectElementButton
+                    nameText={activeInfo.displayString}
+                    properties={
+                      activeProperties ?? {
+                        type: 'KeyPressEventAction',
+                        data: {
+                          keypress: -1,
+                          press_duration: 1,
+                          keytype: KeyType[KeyType.DownUp]
+                        }
+                      }
+                    }
+                  />
+                </AspectRatio>
+              </OverlayDraggableWrapper>
+            ) : undefined}
+          </DragOverlay>
+        </DndContext>
         <EditArea />
       </HStack>
     </VStack>

--- a/src/views/Macroview.tsx
+++ b/src/views/Macroview.tsx
@@ -1,163 +1,21 @@
-import { VStack, HStack, AspectRatio } from '@chakra-ui/react'
+import { VStack, HStack } from '@chakra-ui/react'
 import EditArea from '../components/macroview/rightPanel/EditArea'
-import SelectElementArea from '../components/macroview/leftPanel/SelectElementArea'
-import SequencingArea from '../components/macroview/centerPanel/SequencingArea'
 import Header from '../components/macroview/topArea/Header'
 import { useMacroContext } from '../contexts/macroContext'
-import { useCallback, useEffect, useState } from 'react'
-import {
-  DndContext,
-  DragEndEvent,
-  DragOverlay,
-  DragStartEvent,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors
-} from '@dnd-kit/core'
-import SelectElementButton from '../components/macroview/leftPanel/SelectElementButton'
-import { ActionEventType, ActiveInfo } from '../types'
-import { checkIfKeyboardKey, checkIfMouseEvent } from '../constants/utils'
-import { KeyType } from '../constants/enums'
-import { restrictToWindowEdges } from '@dnd-kit/modifiers'
-import { useSettingsContext } from '../contexts/settingsContext'
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import OverlayDraggableWrapper from '../components/macroview/leftPanel/OverlayDraggableWrapper'
+import { useEffect } from 'react'
+import LeftAndCenterArea from '../components/macroview/LeftAndCenterArea'
 
-type Props = {
+interface Props {
   isEditing: boolean
   onOpenSettingsModal: () => void
 }
 
 export default function Macroview({ isEditing, onOpenSettingsModal }: Props) {
   const { changeIsUpdatingMacro } = useMacroContext()
-  const [activeId, setActiveId] = useState<number | undefined>(undefined)
-  const [activeInfo, setActiveInfo] = useState<ActiveInfo>(undefined)
-  const [ratioVal, setRatioVal] = useState<number | undefined>(undefined)
-  const [activeProperties, setActiveProperties] = useState<
-    ActionEventType | undefined
-  >(undefined)
-  const { sequence, onElementAdd, onElementsAdd } = useMacroContext()
-  const { config } = useSettingsContext()
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 2.5 }
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates
-    })
-  )
 
   useEffect(() => {
     changeIsUpdatingMacro(isEditing)
   }, [changeIsUpdatingMacro, isEditing])
-
-  const handleAddElement = useCallback(
-    (properties: ActionEventType) => {
-      if (config.AutoAddDelay) {
-        if (
-          sequence.at(-1)?.type !== 'DelayEventAction' &&
-          sequence.length > 0
-        ) {
-          onElementsAdd([
-            {
-              type: 'DelayEventAction',
-              data: config.DefaultDelayValue
-            },
-            properties
-          ])
-        } else {
-          onElementAdd(properties)
-        }
-      } else {
-        onElementAdd(properties)
-      }
-    },
-    [
-      config.AutoAddDelay,
-      config.DefaultDelayValue,
-      onElementAdd,
-      onElementsAdd,
-      sequence
-    ]
-  )
-
-  const calculateRatio = useCallback((info: ActiveInfo) => {
-    if (info === undefined) {
-      return
-    }
-    if (checkIfKeyboardKey(info)) {
-      return info.colSpan !== undefined ? info.colSpan / 1 : 1
-    } else {
-      return 2 / 0.75
-    }
-  }, [])
-
-  const getProperties = useCallback((info: ActiveInfo): ActionEventType => {
-    if (info === undefined) {
-      return {
-        type: 'KeyPressEventAction',
-        data: {
-          keypress: -1,
-          press_duration: 1,
-          keytype: KeyType[KeyType.DownUp]
-        }
-      }
-    }
-    if (checkIfKeyboardKey(info)) {
-      return {
-        type: 'KeyPressEventAction',
-        data: {
-          keypress: info.HIDcode,
-          press_duration: 1,
-          keytype: KeyType[KeyType.DownUp]
-        }
-      }
-    } else if (checkIfMouseEvent(info)) {
-      return {
-        type: 'MouseEventAction',
-        data: {
-          type: 'Press',
-          data: {
-            type: 'DownUp',
-            button: info.enumVal,
-            duration: 20
-          }
-        }
-      }
-    } else {
-      return {
-        type: 'SystemEventAction',
-        data: info.defaultData
-      }
-    }
-  }, [])
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { over } = event
-      if (activeProperties && over && over.id === 'sortableList') {
-        handleAddElement(activeProperties)
-      }
-      setActiveId(undefined)
-      setRatioVal(undefined)
-      setActiveProperties(undefined)
-    },
-    [activeProperties, handleAddElement]
-  )
-
-  const handleDragStart = useCallback(
-    (event: DragStartEvent) => {
-      const { active } = event
-      if (active.data.current) {
-        setActiveInfo(active.data.current.info)
-        setRatioVal(calculateRatio(active.data.current.info))
-        setActiveProperties(getProperties(active.data.current.info))
-      }
-      setActiveId(Number(active.id))
-    },
-    [calculateRatio, getProperties]
-  )
 
   return (
     <VStack h="full" spacing="0px" overflow="hidden">
@@ -173,38 +31,7 @@ export default function Macroview({ isEditing, onOpenSettingsModal }: Props) {
         spacing="0"
       >
         {/** Bottom Panels */}
-        <DndContext
-          sensors={sensors}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-        >
-          <SelectElementArea />
-          <SequencingArea onOpenSettingsModal={onOpenSettingsModal} />
-          <DragOverlay zIndex={2} modifiers={[restrictToWindowEdges]}>
-            {activeInfo && activeId ? (
-              <OverlayDraggableWrapper
-                id={activeInfo.displayString}
-                info={activeInfo}
-              >
-                <AspectRatio ratio={ratioVal ?? 1}>
-                  <SelectElementButton
-                    nameText={activeInfo.displayString}
-                    properties={
-                      activeProperties ?? {
-                        type: 'KeyPressEventAction',
-                        data: {
-                          keypress: -1,
-                          press_duration: 1,
-                          keytype: KeyType[KeyType.DownUp]
-                        }
-                      }
-                    }
-                  />
-                </AspectRatio>
-              </OverlayDraggableWrapper>
-            ) : undefined}
-          </DragOverlay>
-        </DndContext>
+        <LeftAndCenterArea onOpenSettingsModal={onOpenSettingsModal} />
         <EditArea />
       </HStack>
     </VStack>

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -2,7 +2,7 @@ import { HStack } from '@chakra-ui/react'
 import LeftPanel from '../components/overview/LeftPanel'
 import CollectionPanel from '../components/overview/CollectionPanel'
 
-type Props = {
+interface Props {
   onOpenSettingsModal: () => void
 }
 

--- a/src/views/SettingsModal.tsx
+++ b/src/views/SettingsModal.tsx
@@ -22,7 +22,7 @@ import SettingsLeftPanel from '../components/settings/SettingsLeftPanel'
 import useScrollbarStyles from '../hooks/useScrollbarStyles'
 import useMainBgColour from '../hooks/useMainBgColour'
 
-type Props = {
+interface Props {
   isOpen: boolean
   onClose: () => void
 }


### PR DESCRIPTION
This small update **allows users to drag elements from the left panel of the Macroview into the sortable list** to add them into the sequence. There are also some smaller, aesthetic adjustments to the Right Panel (Edit Panel).

## Changelog
- Left and Center panels of the Macroview have been refactored into LeftAndCenterArea.tsx. These sections have been wrapped in a new DndContext.
- Alongside that, another DragOverlay has been added to encompass the left and center areas.
- The SelectElementButton has been wrapped around a new Draggable wrapper. The OverlayDraggableWrapper is similar but just used for the DragOverlay. They can be dragged within the window.
- The SortableList has been wrapped by a new Droppable Wrapper. This wrapper defines where a draggable element can be "dropped". It alters the background colour of the sortable list when a draggable is hovering over it.
- Named some union types and added them to types.ts, to reduce redundancy and make it so you only need to adjust them in one place.
- Added a fade animation to the edit panel to make switching between different types of elements less jarring (should be smoother now)
- Adjusted some spacing of the edit panel forms