### PR TITLE
Mouse 1 Passthrough

### DIFF
--- a/wooting-macro-backend/src/lib.rs
+++ b/wooting-macro-backend/src/lib.rs
@@ -580,10 +580,11 @@ impl MacroBackend {
                                 channel_clone,
                             );
 
-                            if should_grab {
-                                None
-                            } else {
-                                Some(event)
+                            // Left mouse button never gets consumed to allow users to control their PC.
+                            match (should_grab, button) {
+                                (true, rdev::Button::Left) => Some(event),
+                                (true, _) => None,
+                                (false, _) => Some(event),
                             }
                         }
                         rdev::EventType::ButtonRelease(button) => {


### PR DESCRIPTION
Mouse 1 needs to pass through every time, else you can lose control of your PC. 