### PR TITLE
feat: disable tauri keyboard shortcuts + fix: macroview button grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,12 @@ function App() {
 
   useEffect(() => {
     document.addEventListener('contextmenu', (event) => event.preventDefault()) // disables tauri's right click context menu
-    // TODO: Figure out how to disable other keyboard shortcuts like CTRL-F
+    // TODO: Add disable for ctrl+r and f5, but only when in debug mode - envvar RUST_LOG='debug'
+    document.addEventListener('keydown', (event) => {
+      if((event.key == 'LCtrl' || event.key == 'RCtrl') && event.key == 'F'){
+        event.preventDefault();
+      }
+    });
     init({ data })
   }, [])
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ function App() {
         event.preventDefault();
       }
     });
+    document.addEventListener('selectstart', (event) => event.preventDefault())
     init({ data })
   }, [])
 

--- a/src/components/macroview/leftPanel/AccordionComponents/MouseButtonsSection.tsx
+++ b/src/components/macroview/leftPanel/AccordionComponents/MouseButtonsSection.tsx
@@ -38,8 +38,8 @@ export default function MouseButtonsSection({ elementsToRender }: Props) {
           h="fit"
           columns={{
             base: 2,
-            md: 4,
-            xl: 6
+            md: 3,
+            xl: 4
           }}
           px={4}
           spacing={2}

--- a/src/components/macroview/leftPanel/SelectElementButton.tsx
+++ b/src/components/macroview/leftPanel/SelectElementButton.tsx
@@ -63,6 +63,7 @@ export default function SelectElementButton({
         h="full"
         as="button"
         bg={bg}
+        p={2}
         _hover={{ bg: hoverBg }}
         color={textColor}
         border="1px"

--- a/src/components/macroview/leftPanel/SelectElementButton.tsx
+++ b/src/components/macroview/leftPanel/SelectElementButton.tsx
@@ -63,7 +63,6 @@ export default function SelectElementButton({
         h="full"
         as="button"
         bg={bg}
-        p={2}
         _hover={{ bg: hoverBg }}
         color={textColor}
         border="1px"


### PR DESCRIPTION
Disabled CTRL+F tauri keyboard shortcut.
Disabled selecting with LMB.
Fixed macroview leftpanel button grid, yields much better results on weird screen resolutions.