### PR TITLE
Added Trigger On Release #218

### DIFF
--- a/src/components/macroview/topArea/MacroTypeArea.tsx
+++ b/src/components/macroview/topArea/MacroTypeArea.tsx
@@ -12,10 +12,12 @@ import {
   VStack
 } from '@chakra-ui/react'
 import {
+  HiArrowDown,
   HiArrowDownTray,
   HiArrowPath,
   HiArrowPathRoundedSquare,
-  HiArrowRight
+  HiArrowRight,
+  HiArrowUp
 } from 'react-icons/hi2'
 import { useMacroContext } from '../../../contexts/macroContext'
 import { MacroType, MacroTypeDefinitions } from '../../../constants/enums'
@@ -30,7 +32,8 @@ export default function MacroTypeArea() {
   const secondBg = useColorModeValue('blue.50', 'gray.900')
   const primaryBg = useMainBgColour()
   const typeIcons = [
-    <HiArrowRight />,
+    <HiArrowDown />,
+    <HiArrowUp />,
     <HiArrowPath />,
     <HiArrowDownTray />,
     <HiArrowPathRoundedSquare />

--- a/src/constants/enums.ts
+++ b/src/constants/enums.ts
@@ -7,6 +7,7 @@ export enum ViewState {
 /** Currently unused */
 export enum MacroType {
   Single,
+  Release,
   Toggle,
   OnHold, // TODO: need to add space later when displaying the macro type name text
   RepeatX,
@@ -17,6 +18,7 @@ export enum MacroType {
 /** Currently unused */
 export const MacroTypeDefinitions: string[] = [
   'SINGLE:\nThe macro will play once after the trigger key(s) is pressed.',
+  'RELEASE:\nThe macro will play once after the trigger key(s) is released.',
   'TOGGLE (BETA):\nThe macro will continuously repeat until the trigger key(s) is pressed again.',
   'ON HOLD (BETA):\nThe macro will only play while the trigger key(s) is pressed.',
   'REPEAT:\nThe macro will play X amount of times after the trigger key(s) is pressed.',

--- a/wooting-macro-backend/src/grabbing/windows_linux/input.rs
+++ b/wooting-macro-backend/src/grabbing/windows_linux/input.rs
@@ -4,12 +4,11 @@ pub mod input {
     use std::sync::Arc;
     use std::time;
 
-    use itertools::Itertools;
     use rdev::EventType;
     use tokio::sync::mpsc::UnboundedSender;
 
     use crate::grabbing::executor::input::MacroExecutorEvent;
-    use crate::grabbing::windows_linux::matcher::input::check_macro_execution_simply;
+    use crate::grabbing::windows_linux::matcher::input::{check_release_macro_execution, check_press_macro_execution};
     use crate::hid_table::*;
     use crate::macros::macro_data::MacroLookup;
 
@@ -22,76 +21,65 @@ pub mod input {
     ) {
         tokio::time::sleep(time::Duration::from_millis(3000)).await;
 
-        let og_previously_pressed_keys: Arc<RwLock<Vec<u32>>> = Arc::new(RwLock::from(vec![]));
-        let og_current_pressed_keys: Arc<RwLock<Vec<u32>>> = Arc::new(RwLock::from(vec![]));
+        let og_pressed_modifier_keys: Arc<RwLock<Vec<u32>>> = Arc::new(RwLock::from(vec![]));
 
         let _grabber = tokio::task::spawn_blocking(move || {
             let schan_macro_execute_inner = schan_macro_execute.clone();
-            let current_pressed_keys = og_current_pressed_keys.clone();
-            let previously_pressed_keys = og_previously_pressed_keys.clone();
+            let pressed_modifier_keys = og_pressed_modifier_keys.clone();
 
             rdev::grab(move |event: rdev::Event| {
                 if inner_is_listening.load(Ordering::Relaxed) {
                     match event.event_type {
-                        // Only check KeyPress and not SimulatedKeyPress
                         EventType::KeyPress(key) => {
-                            // Add the keys to the array
-                            current_pressed_keys
-                                .blocking_write()
-                                .push(*RDEV_TO_HID.get(&key).unwrap_or(&0));
+                            let hid_key = RDEV_TO_HID.get(&key).unwrap_or(&0);
+                            if RDEV_MODIFIER_KEYS.contains(&key) {
+                                pressed_modifier_keys.blocking_write().push(*hid_key);
+                            }
 
-                            // Make a copy of current values to prevent a deadlock
-                            let current_pressed_keys_clone =
-                                current_pressed_keys.blocking_read().clone();
-
-                            // Rewrite the current values with unique values
-                            *current_pressed_keys.blocking_write() =
-                                current_pressed_keys_clone.into_iter().unique().collect();
-
-                            // Check if the macro corresponds and if to consume the trigger
-                            let consume = check_macro_execution_simply(
-                                &current_pressed_keys.blocking_read(),
-                                &previously_pressed_keys.blocking_read(),
+                            let consume = check_press_macro_execution(
+                                &pressed_modifier_keys.blocking_read(),
+                                hid_key,
                                 map.clone(),
                                 &schan_macro_execute_inner,
                             );
 
-                            // Consume trigger if matched a macro, else let all keys pass
                             if consume {
-                                // debug!("CONSUMING {:?}", key);
                                 None
                             } else {
                                 Some(event)
                             }
                         }
-                        // Only check KeyRelease and not Simulated Key Release
+
                         EventType::KeyRelease(key) => {
-                            previously_pressed_keys
-                                .blocking_write()
-                                .clone_from(&current_pressed_keys.blocking_read());
+                            let hid_key = RDEV_TO_HID.get(&key).unwrap_or(&0);
 
-                            current_pressed_keys
-                                .blocking_write()
-                                .retain(|x| x != RDEV_TO_HID.get(&key).unwrap_or(&0));
+                            if RDEV_MODIFIER_KEYS.contains(&key) {
+                                pressed_modifier_keys
+                                    .blocking_write()
+                                    .retain(|x| x != hid_key);
+                            }
 
-                            // Check if the macro corresponds and if to consume the trigger
-                            let _ = check_macro_execution_simply(
-                                &current_pressed_keys.blocking_read(),
-                                &previously_pressed_keys.blocking_read(),
+                            let consume = check_release_macro_execution(
+                                &pressed_modifier_keys.blocking_read(),
+                                hid_key,
                                 map.clone(),
                                 &schan_macro_execute_inner,
                             );
 
-                            // We always send the release event of a key, since there's no harm to it.
-                            Some(event)
+                            if consume {
+                                None
+                            } else {
+                                Some(event)
+                            }
                         }
-                        EventType::ButtonPress(button) => {
-                            let converted_button_hid: Vec<u32> =
-                                vec![BUTTON_TO_HID.get(&button).unwrap_or(&0x101).to_owned()];
 
-                            let consume = check_macro_execution_simply(
-                                &converted_button_hid,
-                                &previously_pressed_keys.blocking_read(),
+                        EventType::ButtonPress(button) => {
+                            let hid_key: u32 =
+                                BUTTON_TO_HID.get(&button).unwrap_or(&0x101).to_owned();
+
+                            let consume = check_press_macro_execution(
+                                &pressed_modifier_keys.blocking_read(),
+                                &hid_key,
                                 map.clone(),
                                 &schan_macro_execute_inner,
                             );

--- a/wooting-macro-backend/src/grabbing/windows_linux/matcher.rs
+++ b/wooting-macro-backend/src/grabbing/windows_linux/matcher.rs
@@ -9,63 +9,32 @@ pub mod input {
 
     use crate::macros::events::triggers::TriggerEventType;
     use crate::macros::macro_data::MacroLookup;
-    use crate::macros::macros::MacroType;
 
-    pub fn check_macro_execution_simply(
-        current_pressed_keys: &Vec<u32>,
-        previously_pressed_keys: &Vec<u32>,
+    pub fn check_press_macro_execution(
+        pressed_modifier_keys: &Vec<u32>,
+        key: &u32,
         triggers: Arc<RwLock<MacroLookup>>,
         schan_macro_execute: &UnboundedSender<MacroExecutorEvent>,
     ) -> bool {
         let mut return_value = false;
         for (macro_id, macro_data) in triggers.blocking_read().id_map.iter() {
-            // Get the macro trigger
             match &macro_data.config.trigger {
                 TriggerEventType::KeyPressEvent { data, .. } => {
-                    match (data, &current_pressed_keys, &previously_pressed_keys) {
-                        // If the keys are the same, skip checking
-                        (_trigger_combo, pressed, pressed_previous)
-                            if pressed == pressed_previous
-                                && macro_data.config.macro_type == MacroType::OnHold =>
-                        {
-                            // Consumption of the trigger key (when held)
-                            return_value = false;
-                        }
-                        // If the keys are different and its a trigger key pressed, start a macro
-                        (trigger_combo, pressed, _pressed_previous)
-                            if trigger_combo.iter().all(|x| pressed.contains(x)) =>
-                        {
-                            schan_macro_execute
-                                .send(MacroExecutorEvent::Start(macro_id.clone()))
-                                .unwrap();
-                            // Consumption of the trigger key (when macro triggered)
-                            return_value = true;
-                        }
-                        // If the keys are different and its a trigger key released, stop a macro
-                        (trigger_combo, _pressed, pressed_previous)
-                            if trigger_combo.iter().all(|x| pressed_previous.contains(x)) =>
-                        {
-                            schan_macro_execute
-                                .send(MacroExecutorEvent::Stop(macro_id.clone()))
-                                .unwrap();
-
-                            // We don't consume the value here.
-                        }
-                        // Anything else just ignore
-                        _ => {}
+                    let mut keys = pressed_modifier_keys.clone();
+                    keys.push(*key);
+                    if data.iter().all(|x| keys.contains(x)) {
+                        schan_macro_execute
+                            .send(MacroExecutorEvent::Start(macro_id.clone()))
+                            .unwrap();
+                        return_value = true;
                     }
                 }
                 TriggerEventType::MouseEvent { data } => {
-                    match (data, current_pressed_keys, previously_pressed_keys) {
-                        (trigger_combo, pressed, _pressed_previous)
-                            if pressed.iter().all(|x: &u32| u32::from(trigger_combo) == *x) =>
-                        {
-                            schan_macro_execute
-                                .send(MacroExecutorEvent::Start(macro_id.clone()))
-                                .unwrap();
-                            return_value = true;
-                        }
-                        _ => {}
+                    if *key == u32::from(data) {
+                        schan_macro_execute
+                            .send(MacroExecutorEvent::Start(macro_id.clone()))
+                            .unwrap();
+                        return_value = true;
                     }
                 }
             }
@@ -73,4 +42,36 @@ pub mod input {
 
         return_value
     }
+
+    pub fn check_release_macro_execution(
+        _pressed_modifier_keys: &Vec<u32>,
+        key: &u32,
+        triggers: Arc<RwLock<MacroLookup>>,
+        schan_macro_execute: &UnboundedSender<MacroExecutorEvent>,
+    ) -> bool {
+        let mut return_value = false;
+        for (macro_id, macro_data) in triggers.blocking_read().id_map.iter() {
+            match &macro_data.config.trigger {
+                TriggerEventType::KeyPressEvent { data, .. } => {
+                    if data.last().unwrap() == key {
+                        schan_macro_execute
+                            .send(MacroExecutorEvent::Stop(macro_id.clone()))
+                            .unwrap();
+                        return_value = true;
+                    }
+
+                }
+                TriggerEventType::MouseEvent { data } => {
+                    if *key == u32::from(data) {
+                        schan_macro_execute
+                            .send(MacroExecutorEvent::Stop(macro_id.clone()))
+                            .unwrap();
+                        return_value = true;
+                    }
+                }
+            }
+        }
+        return_value
+    }
 }
+

--- a/wooting-macro-backend/src/macros/macros.rs
+++ b/wooting-macro-backend/src/macros/macros.rs
@@ -44,6 +44,12 @@ impl Macro {
                     self.task_sender.send(MacroTaskEvent::OneShot).unwrap();
                 }
             }
+            MacroType::Release => {
+                if let MacroTriggerEvent::Released = event {
+                    warn!("Sending oneshot macro");
+                    self.task_sender.send(MacroTaskEvent::OneShot).unwrap();
+                }
+            }
             MacroType::Toggle => {
                 if let MacroTriggerEvent::Pressed = event {
                     warn!("Toggling");
@@ -80,6 +86,8 @@ impl Macro {
 pub enum MacroType {
     // Single macro fire
     Single,
+    // Trigger when released
+    Release,
     // press to start, press to finish cycle and terminate
     Toggle,
     // while held Execute macro (repeats)


### PR DESCRIPTION
Added new `MacroType`: 'Release' and updated UI in the `macroview `to reflect that.

Refactored the way inputs are handled by removing the two vectors that gather pressed keys and previously pressed keys and replacing it with a single vector that holds modifier keys that are being pressed.

Created two functions that replace `check_macro_execution_simply`, they take in the modifier keys and the key being acted upon. One of the functions check when there's a **press** input and another when there's a **release** input.