### PR TITLE
feat: Add macro looping functionality with Toggle type

### DIFF
--- a/src/components/macroview/topArea/Header.tsx
+++ b/src/components/macroview/topArea/Header.tsx
@@ -19,6 +19,7 @@ import TriggerArea from './TriggerArea'
 import TriggerModal from './TriggerModal'
 import UnsavedChangesModal from '../UnsavedChangesModal'
 import useMainBgColour from '../../../hooks/useMainBgColour'
+import MacroTypeArea from './MacroTypeArea'
 
 interface Props {
   isEditing: boolean
@@ -174,7 +175,7 @@ export default function Header({ isEditing }: Props) {
             _focusVisible={{ borderColor: 'primary-accent.500' }}
           />
         </Flex>
-        {/* <MacroTypeArea /> */}
+        <MacroTypeArea />
         <Flex maxW="700px" flexGrow={1} gap={4} alignItems="center">
           <TriggerArea onOpen={onTriggerModalOpen} />
           <Tooltip

--- a/src/components/macroview/topArea/MacroTypeArea.tsx
+++ b/src/components/macroview/topArea/MacroTypeArea.tsx
@@ -3,7 +3,15 @@ import {
   IconButton,
   StackDivider,
   Text,
-  useColorModeValue
+  useColorModeValue,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  Checkbox,
+  VStack,
+  Tooltip
 } from '@chakra-ui/react'
 import { HiArrowDownTray, HiArrowPath, HiArrowRight } from 'react-icons/hi2'
 import { useMacroContext } from '../../../contexts/macroContext'
@@ -11,40 +19,110 @@ import { MacroType } from '../../../constants/enums'
 import { checkIfStringIsNonNumeric } from '../../../constants/utils'
 
 export default function MacroTypeArea() {
-  const { macro, updateMacroType } = useMacroContext()
+  const { macro, updateMacroType, updateLoopCount } = useMacroContext()
   const borderColour = useColorModeValue('gray.400', 'gray.600')
-  const typeIcons = [<HiArrowRight />, <HiArrowPath />, <HiArrowDownTray />]
+  const typeIcons = [<HiArrowRight key="single" />, <HiArrowPath key="toggle" />, <HiArrowDownTray key="onhold" />]
+  
+  const isToggleMacro = macro.macro_type === 'Toggle'
+  const isInfiniteLoop = macro.loop_count === null || macro.loop_count === undefined
+
+  const handleInfiniteToggle = (checked: boolean) => {
+    if (checked) {
+      updateLoopCount(null)
+    } else {
+      updateLoopCount(10) // Default to 10 loops when unchecked
+    }
+  }
+
+  const handleLoopCountChange = (valueAsString: string, valueAsNumber: number) => {
+    if (!isNaN(valueAsNumber) && valueAsNumber > 0) {
+      updateLoopCount(valueAsNumber)
+    }
+  }
 
   return (
-    <HStack
-      w="fit"
-      h="fit"
-      p="2"
-      border="1px"
-      borderColor={borderColour}
-      divider={<StackDivider />}
-      rounded='md'
-      spacing="16px"
-    >
-      <Text fontWeight="semibold" fontSize={['sm', 'md']}>
-        Macro Type
-      </Text>
-      <HStack>
-        {(Object.keys(MacroType) as Array<keyof typeof MacroType>)
-          .filter(checkIfStringIsNonNumeric)
-          .map((value: string, index: number) => (
-            <IconButton
-              icon={typeIcons[index]}
-              aria-label="macro type"
-              size="sm"
-              colorScheme={
-                macro.macro_type === value ? 'primary-accent' : 'gray'
-              }
-              onClick={() => updateMacroType(index)}
-              key={value}
-            ></IconButton>
-          ))}
+    <VStack align="stretch" spacing="2">
+      <HStack
+        w="fit"
+        h="fit"
+        p="2"
+        border="1px"
+        borderColor={borderColour}
+        divider={<StackDivider />}
+        rounded='md'
+        spacing="16px"
+      >
+        <Text fontWeight="semibold" fontSize={['sm', 'md']}>
+          Macro Type
+        </Text>
+        <HStack>
+          {(Object.keys(MacroType) as Array<keyof typeof MacroType>)
+            .filter(checkIfStringIsNonNumeric)
+            .map((value: string, index: number) => (
+              <Tooltip 
+                label={
+                  index === 0 ? 'Single: Play once' : 
+                  index === 1 ? 'Toggle: Loop continuously until triggered again' : 
+                  'On Hold: Play while held (Not yet implemented)'
+                }
+                key={value}
+              >
+                <IconButton
+                  icon={typeIcons[index]}
+                  aria-label="macro type"
+                  size="sm"
+                  colorScheme={
+                    macro.macro_type === value ? 'primary-accent' : 'gray'
+                  }
+                  onClick={() => updateMacroType(index)}
+                  isDisabled={index === 2} // Disable OnHold as it's not implemented
+                ></IconButton>
+              </Tooltip>
+            ))}
+        </HStack>
       </HStack>
-    </HStack>
+      
+      {isToggleMacro && (
+        <HStack
+          w="fit"
+          h="fit"
+          p="2"
+          border="1px"
+          borderColor={borderColour}
+          rounded='md'
+          spacing="16px"
+        >
+          <Text fontWeight="semibold" fontSize={['sm', 'md']}>
+            Loop Settings
+          </Text>
+          <Checkbox 
+            isChecked={isInfiniteLoop}
+            onChange={(e) => handleInfiniteToggle(e.target.checked)}
+            size="sm"
+          >
+            <Text fontSize={['xs', 'sm']}>Infinite Loop</Text>
+          </Checkbox>
+          {!isInfiniteLoop && (
+            <HStack spacing="2">
+              <Text fontSize={['xs', 'sm']}>Count:</Text>
+              <NumberInput
+                size="sm"
+                min={1}
+                max={10000}
+                value={macro.loop_count ?? 10}
+                onChange={handleLoopCountChange}
+                w="100px"
+              >
+                <NumberInputField />
+                <NumberInputStepper>
+                  <NumberIncrementStepper />
+                  <NumberDecrementStepper />
+                </NumberInputStepper>
+              </NumberInput>
+            </HStack>
+          )}
+        </HStack>
+      )}
+    </VStack>
   )
 }

--- a/src/contexts/macroContext.tsx
+++ b/src/contexts/macroContext.tsx
@@ -41,7 +41,8 @@ const macroDefault: Macro = {
   active: true,
   macro_type: 'Single',
   trigger: { type: 'KeyPressEvent', data: [], allow_while_other_keys: false },
-  sequence: []
+  sequence: [],
+  loop_count: null
 }
 
 function MacroProvider({ children }: MacroProviderProps) {
@@ -177,6 +178,13 @@ function MacroProvider({ children }: MacroProviderProps) {
   const updateMacroType = useCallback(
     (newType: MacroType) => {
       setMacro({ ...macro, macro_type: MacroType[newType] })
+    },
+    [macro, setMacro]
+  )
+
+  const updateLoopCount = useCallback(
+    (count: number | null) => {
+      setMacro({ ...macro, loop_count: count })
     },
     [macro, setMacro]
   )
@@ -355,6 +363,7 @@ function MacroProvider({ children }: MacroProviderProps) {
       updateMacroName,
       updateMacroIcon,
       updateMacroType,
+      updateLoopCount,
       updateTrigger,
       updateAllowWhileOtherKeys,
       onElementAdd,
@@ -381,6 +390,7 @@ function MacroProvider({ children }: MacroProviderProps) {
       updateMacroName,
       updateMacroIcon,
       updateMacroType,
+      updateLoopCount,
       updateTrigger,
       updateAllowWhileOtherKeys,
       onElementAdd,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,6 +38,7 @@ export type MacroState = {
   updateMacroName: (newName: string) => void
   updateMacroIcon: (newIcon: string) => void
   updateMacroType: (newType: MacroType) => void
+  updateLoopCount: (count: number | null) => void
   updateTrigger: (newElement: TriggerEventType) => void
   updateAllowWhileOtherKeys: (value: boolean) => void
   onElementAdd: (newElement: ActionEventType) => void
@@ -114,6 +115,7 @@ export interface Macro {
   macro_type: string
   trigger: TriggerEventType
   sequence: ActionEventType[]
+  loop_count?: number | null
 }
 
 export interface Collection {

--- a/wooting-macro-backend/src/lib.rs
+++ b/wooting-macro-backend/src/lib.rs
@@ -11,10 +11,10 @@ use halfbrown::HashMap;
 use itertools::Itertools;
 use log::*;
 use rayon::prelude::*;
-use rdev::simulate;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::RwLock;
 use tokio::task;
+use tokio::sync::Mutex;
 
 use config::{ApplicationConfig, ConfigFile};
 
@@ -105,6 +105,9 @@ pub struct Macro {
     pub macro_type: MacroType,
     pub trigger: TriggerEventType,
     pub active: bool,
+    /// Optional: Maximum number of loop iterations for Toggle macros (None = infinite)
+    #[serde(default)]
+    pub loop_count: Option<u32>,
 }
 
 impl Macro {
@@ -169,6 +172,9 @@ type Collections = Vec<Collection>;
 /// Hashmap to check the first trigger key of each macro.
 type MacroTriggerLookup = HashMap<u32, Vec<Macro>>;
 
+/// Tracks active toggle macros by their name (used as unique identifier)
+type ActiveToggleMacros = Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>;
+
 /// State of the application in RAM (RWlock).
 #[derive(Debug)]
 pub struct MacroBackend {
@@ -176,6 +182,7 @@ pub struct MacroBackend {
     pub config: Arc<RwLock<ApplicationConfig>>,
     pub triggers: Arc<RwLock<MacroTriggerLookup>>,
     pub is_listening: Arc<AtomicBool>,
+    pub active_toggles: ActiveToggleMacros,
 }
 
 ///MacroData is the main data structure that contains all macro data.
@@ -263,8 +270,13 @@ pub struct Collection {
 
 /// Executes a given macro (according to its type).
 ///
-/// ! **UNIMPLEMENTED** - Only Single macro type is implemented for now.
-async fn execute_macro(macros: Macro, channel: UnboundedSender<rdev::EventType>) {
+/// For Toggle macros, returns the task handle so it can be cancelled later.
+/// ! **UNIMPLEMENTED** - OnHold macro type is not yet implemented.
+async fn execute_macro(
+    macros: Macro,
+    channel: UnboundedSender<rdev::EventType>,
+    active_toggles: ActiveToggleMacros,
+) {
     match macros.macro_type {
         MacroType::Single => {
             info!("\nEXECUTING A SINGLE MACRO: {:#?}", macros.name);
@@ -278,12 +290,51 @@ async fn execute_macro(macros: Macro, channel: UnboundedSender<rdev::EventType>)
             });
         }
         MacroType::Toggle => {
-            //Postponed
-            //execute_macro_toggle(&macros).await;
+            info!("\nTOGGLING MACRO: {:#?}", macros.name);
+            
+            let macro_name = macros.name.clone();
+            let mut active_toggles_lock = active_toggles.lock().await;
+            
+            // Check if this toggle macro is already running
+            if let Some(handle) = active_toggles_lock.remove(&macro_name) {
+                // Stop the running macro
+                info!("Stopping toggle macro: {}", macro_name);
+                handle.abort();
+            } else {
+                // Start the toggle macro
+                info!("Starting toggle macro: {}", macro_name);
+                let loop_count = macros.loop_count;
+                let handle = task::spawn(async move {
+                    let mut iteration = 0u32;
+                    loop {
+                        // Check if we've reached the loop limit
+                        if let Some(max_loops) = loop_count {
+                            if iteration >= max_loops {
+                                info!("Toggle macro {} reached loop limit of {}", macros.name, max_loops);
+                                break;
+                            }
+                        }
+                        
+                        if let Err(error) = macros.execute(channel.clone()).await {
+                            error!("error executing toggle macro: {}", error);
+                            break;
+                        }
+                        
+                        iteration += 1;
+                        
+                        // Small delay between iterations to prevent overwhelming the system
+                        tokio::time::sleep(time::Duration::from_millis(10)).await;
+                    }
+                    info!("Toggle macro {} stopped after {} iterations", macros.name, iteration);
+                });
+                
+                active_toggles_lock.insert(macro_name, handle);
+            }
         }
         MacroType::OnHold => {
             //Postponed
             //execute_macro_onhold(&macros).await;
+            warn!("OnHold macro type not yet implemented");
         }
     }
 }
@@ -314,10 +365,13 @@ fn keypress_executor_sender(mut rchan_execute: UnboundedReceiver<rdev::EventType
 /// `trigger_overview` - Macros that need to be checked. Should be picked by matching the hashtable of triggers, and those should be checked here.
 ///
 /// `channel_sender` - a copy of the channel sender to use later when executing various macros.
+///
+/// `active_toggles` - reference to active toggle macros for managing their state.
 fn check_macro_execution_efficiently(
     pressed_events: Vec<u32>,
     trigger_overview: Vec<Macro>,
     channel_sender: UnboundedSender<rdev::EventType>,
+    active_toggles: ActiveToggleMacros,
 ) -> bool {
     let trigger_overview_print = trigger_overview.clone();
 
@@ -335,12 +389,13 @@ fn check_macro_execution_efficiently(
 
                             let channel_clone_execute = channel_sender.clone();
                             let macro_clone_execute = macros.clone();
+                            let active_toggles_clone = active_toggles.clone();
 
                             // We don't need this here as there can't be a single key that's a modifier
                             // plugin::util::lift_keys(data, &channel_clone_execute);
 
                             task::spawn(async move {
-                                execute_macro(macro_clone_execute, channel_clone_execute).await;
+                                execute_macro(macro_clone_execute, channel_clone_execute, active_toggles_clone).await;
                             });
                             output = true;
                         }
@@ -356,13 +411,14 @@ fn check_macro_execution_efficiently(
 
                             let channel_clone_execute = channel_sender.clone();
                             let macro_clone_execute = macros.clone();
+                            let active_toggles_clone = active_toggles.clone();
 
                             // This releases any trigger keys that have been held to make macros more reliable when used with modifier hotkeys.
                             plugin::util::lift_keys(data, &channel_clone_execute)
                                 .unwrap_or_else(|err| error!("Error lifting keys: {}", err));
 
                             task::spawn(async move {
-                                execute_macro(macro_clone_execute, channel_clone_execute).await;
+                                execute_macro(macro_clone_execute, channel_clone_execute, active_toggles_clone).await;
                             });
                             output = true;
                         }
@@ -381,9 +437,10 @@ fn check_macro_execution_efficiently(
                 if event_to_check == pressed_events {
                     let channel_clone = channel_sender.clone();
                     let macro_clone = macros.clone();
+                    let active_toggles_clone = active_toggles.clone();
 
                     task::spawn(async move {
-                        execute_macro(macro_clone, channel_clone).await;
+                        execute_macro(macro_clone, channel_clone, active_toggles_clone).await;
                     });
                     output = true;
                 }
@@ -444,6 +501,7 @@ impl MacroBackend {
 
         let inner_triggers = self.triggers.clone();
         let inner_is_listening = self.is_listening.clone();
+        let inner_active_toggles = self.active_toggles.clone();
 
         // Spawn the channels
         let (schan_execute, rchan_execute) = tokio::sync::mpsc::unbounded_channel();
@@ -508,10 +566,12 @@ impl MacroBackend {
                             let should_grab = {
                                 if !check_these_macros.is_empty() {
                                     let channel_copy_send = schan_execute.clone();
+                                    let active_toggles_copy = inner_active_toggles.clone();
                                     check_macro_execution_efficiently(
                                         pressed_keys_copy_converted,
                                         check_these_macros,
                                         channel_copy_send,
+                                        active_toggles_copy,
                                     )
                                 } else {
                                     false
@@ -550,11 +610,13 @@ impl MacroBackend {
                                 };
 
                             let channel_clone = schan_execute.clone();
+                            let active_toggles_copy = inner_active_toggles.clone();
 
                             let should_grab = check_macro_execution_efficiently(
                                 vec![converted_button_to_u32],
                                 check_these_macros,
                                 channel_clone,
+                                active_toggles_copy,
                             );
 
                             // Left mouse button never gets consumed to allow users to control their PC.
@@ -597,6 +659,7 @@ impl Default for MacroBackend {
             )),
             triggers: Arc::new(RwLock::from(triggers)),
             is_listening: Arc::new(AtomicBool::new(true)),
+            active_toggles: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }


### PR DESCRIPTION
- Implement Toggle macro type that loops continuously or for a specified count
- Add loop_count field to Macro struct (optional, None = infinite loop)
- Add active_toggles state tracking in MacroBackend to manage running toggle macros
- Toggle macros can be started/stopped by pressing trigger key again
- Add UI controls for loop settings (infinite loop checkbox and count input)
- Add tooltips to explain each macro type
- Uncomment MacroTypeArea component in Header to display macro type selector
- Add updateLoopCount function to MacroContext
- Add 10ms delay between loop iterations to prevent system overload